### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -14,6 +14,8 @@ on:
   workflow_dispatch:
 
 name: Standard
+permissions:
+  contents: read
 
 jobs:
   ci:


### PR DESCRIPTION
Potential fix for [https://github.com/claytonsilva/realpark-documents-ocr2data/security/code-scanning/1](https://github.com/claytonsilva/realpark-documents-ocr2data/security/code-scanning/1)

To fix this issue, we need to add an explicit `permissions:` block at either the workflow level (top-level, applies to all jobs) or the job level (just inside the `ci:` job definition). The minimal starting point is `contents: read`, but if the job requires additional elevated privileges (such as `pull-requests: write`) for specific tasks, those should be added as needed. In the given code, the workflow seems to only need read access for checking out code and running tests. Thus, adding `permissions: contents: read` is sufficient and safest.

Best practice is to add the `permissions` block at the top-level of the workflow, immediately after the `name:` line and before `jobs:`, so all jobs default to least privilege unless otherwise specified. If finer-grained control is needed per job, the block may be placed under the specific job instead.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
